### PR TITLE
Memory savings

### DIFF
--- a/particle.h
+++ b/particle.h
@@ -25,7 +25,6 @@ struct Particle {
         uint8_t counter = 0;
         uint8_t pSize = 1;
         uint8_t type = 1;
-        int16_t boundL, boundR;
         uint8_t wordNum;
 
     public:
@@ -59,31 +58,34 @@ struct Particle {
 
           this->vely -= gravity * this->pSize;
           this->velx *= cF;
+		  
+		  uint8_t boundL = 0;
+		  uint8_t boundR = WIDTH;
 
           if( this->type == 1 ){
-            this->boundL = boardOffset+2;
-            this->boundR = (boardWidth*partSize)+2+boardOffset;
+            boundL = boardOffset+2;
+            boundR = (boardWidth*partSize)+2+boardOffset;
           }
           else if( this->type ==0){
-            this->boundL = 0;
-            this->boundR = 128;
+            boundL = 0;
+            boundR = WIDTH;
           }
           else if( this->type ==2){
-            this->boundL = 0;  
-            this->boundR = boardOffset;
+            boundL = 0;  
+            boundR = boardOffset;
           }
           else if( this->type ==3){
-            this->boundL = (boardWidth*partSize)+boardOffset+4;  
-            this->boundR = 128;
+            boundL = (boardWidth*partSize)+boardOffset+4;  
+            boundR = WIDTH;
           }
                     
-          if(this->x > this->boundR - this->pSize ){
-            this->x = this->boundR - this->pSize ;
+          if(this->x > boundR - this->pSize ){
+            this->x = boundR - this->pSize ;
             this->velx = -this->velx;
             
           }
-          if(this->x < this->boundL){
-            this->x = this->boundL;
+          if(this->x < boundL){
+            this->x = boundL;
             this->velx = -this->velx;
           }
           

--- a/particle.h
+++ b/particle.h
@@ -58,9 +58,9 @@ struct Particle {
 
           this->vely -= gravity * this->pSize;
           this->velx *= cF;
-		  
-		  uint8_t boundL = 0;
-		  uint8_t boundR = WIDTH;
+          
+          uint8_t boundL = 0;
+          uint8_t boundR = WIDTH;
 
           if( this->type == 1 ){
             boundL = boardOffset+2;

--- a/particle.h
+++ b/particle.h
@@ -5,6 +5,8 @@
  * 
  * 
  */
+ 
+#include <FixedPointsCommon.h>
 
 #define boardWidth 5
 #define boardHeight 10
@@ -17,8 +19,8 @@ struct Particle {
 
         int16_t x = 0;
         int16_t y = 0;
-        float velx = 0;
-        float vely = 0;
+        SQ7x8 velx = 0;
+        SQ7x8 vely = 0;
         uint8_t counterInit = 0;
         uint8_t counter = 0;
         uint8_t pSize = 1;
@@ -28,9 +30,9 @@ struct Particle {
 
     public:
 
-        static constexpr float rThresh = 0.000001 * 16;
-        static constexpr float cF = 0.96;
-        static constexpr float gravity = 0.12;
+        static constexpr SQ7x8 rThresh = 0.000001 * 16;
+        static constexpr SQ7x8 cF = 0.96;
+        static constexpr SQ7x8 gravity = 0.12;
 
         int16_t getX()                          { return this->x; }
         int16_t getY()                          { return this->y; }
@@ -42,8 +44,8 @@ struct Particle {
         void setX(int16_t val)                  { this->x = val; }
         void setY(int16_t val)                  { this->y = val; }
         void setCounter(int16_t val)             { this->counter = val; this->counterInit = val; }
-        void setVelX(float val)                  { this->velx = val; }
-        void setVelY(float val)                  { this->vely = val; }
+        void setVelX(SQ7x8 val)                  { this->velx = val; }
+        void setVelY(SQ7x8 val)                  { this->vely = val; }
         void setSize(uint8_t val)                { this->pSize = val; }
         void setType(int val)                { this->type = val; }
         void setWord(int val)                { this->wordNum = val; } 
@@ -106,8 +108,8 @@ struct Particle {
             }           
           }
           
-          this->x += this->velx;
-          this->y -= this->vely;
+          this->x += static_cast<int8_t>(this->velx);
+          this->y -= static_cast<int8_t>(this->vely);
 
           // shift size
           


### PR DESCRIPTION
This is enough to bring it under the warning level so it'll possibly fix the 'magic key' overwriting issue, but possibly not, who knows.

---

Before:
> Sketch uses 14830 bytes (51%) of program storage space. Maximum is 28672 bytes.
Global variables use 2156 bytes (84%) of dynamic memory, leaving 404 bytes for local variables. Maximum is 2560 bytes.

After:
> Sketch uses 14440 bytes (50%) of program storage space. Maximum is 28672 bytes.
Global variables use 1836 bytes (71%) of dynamic memory, leaving 724 bytes for local variables. Maximum is 2560 bytes.